### PR TITLE
docs: TestFlight link → nWeQzmBX (Sodalite)

### DIFF
--- a/BETA.md
+++ b/BETA.md
@@ -17,7 +17,7 @@ For the long pitch see the [README](README.md).
 
 ## Install the build
 
-1. On any device signed in with your Apple ID, open the public TestFlight link: **https://testflight.apple.com/join/eFKDaaXr**
+1. On any device signed in with your Apple ID, open the public TestFlight link: **https://testflight.apple.com/join/nWeQzmBX**
 2. Tap **Accept** and **Install** — TestFlight handles the rest
 3. On your Apple TV, install the **TestFlight** app from the App Store if it isn't already there
 4. Sign in with the same Apple ID; **Sodalite** appears in the list — tap **Install**

--- a/Marketing/Launch.md
+++ b/Marketing/Launch.md
@@ -6,7 +6,7 @@ The vibe-coded disclosure is in every post on purpose. Self-hosted and Apple-pla
 
 ## Step 0: Pre-flight
 
-* Public TestFlight link: `https://testflight.apple.com/join/eFKDaaXr`
+* Public TestFlight link: `https://testflight.apple.com/join/nWeQzmBX`
 * Public beta version: **0.3.2** — stable, plenty of internal testing, ready for outside eyes
 * Apple TV Top Shelf integration and Siri voice commands are landed in `main` but **not yet in the public beta** (planned for 0.4.0). Keep them out of the launch copy below so installers don't go looking for features that aren't there yet.
 * Privacy policy + imprint live at `https://sodalite.superuser404.de`
@@ -28,7 +28,7 @@ Public Beta is live. TestFlight link inside.
 ```markdown
 Sodalite is now in public beta on TestFlight.
 
-**Install:** https://testflight.apple.com/join/eFKDaaXr
+**Install:** https://testflight.apple.com/join/nWeQzmBX
 
 You need an Apple TV 4K running tvOS 26 or later, plus your own Jellyfin server.
 
@@ -112,7 +112,7 @@ I built Sodalite, a native Apple TV client for Jellyfin with first-class Jellyse
 
 [2x2 screenshot collage embedded here]
 
-**TestFlight:** https://testflight.apple.com/join/eFKDaaXr
+**TestFlight:** https://testflight.apple.com/join/nWeQzmBX
 **Source:** https://github.com/superuser404notfound/Sodalite
 
 ## What it is
@@ -178,7 +178,7 @@ If you self-host Jellyfin and have an Apple TV in the living room, Sodalite migh
 
 [2x2 screenshot collage embedded here]
 
-**TestFlight:** https://testflight.apple.com/join/eFKDaaXr
+**TestFlight:** https://testflight.apple.com/join/nWeQzmBX
 **Source and audit:** https://github.com/superuser404notfound/Sodalite
 **Privacy policy:** https://sodalite.superuser404.de/privacy (zero data collected)
 
@@ -240,7 +240,7 @@ For the Jellyfin users in here: Sodalite is now in public TestFlight beta.
 
 [2x2 screenshot collage embedded here]
 
-**Install:** https://testflight.apple.com/join/eFKDaaXr
+**Install:** https://testflight.apple.com/join/nWeQzmBX
 
 Native tvOS app. Proper transport bar, focus engine, HDR and Dolby Vision display switching, Dolby Atmos via EAC3+JOC passthrough. Built ground-up on SwiftUI plus a custom video engine. Cold-launches quickly, scrolls smoothly, stays out of the way.
 
@@ -264,7 +264,7 @@ Sodalite: open-source native Jellyfin client for Apple TV with built-in Jellysee
 
 Fast. Lean. Real HDR10. Real Dolby Vision. Real Dolby Atmos. No telemetry, no analytics, no third-party SDKs. GPL-3.0 with App Store Exception. Vibe-coded with Claude, every change reviewed, source is open.
 
-TestFlight: https://testflight.apple.com/join/eFKDaaXr
+TestFlight: https://testflight.apple.com/join/nWeQzmBX
 Source: https://github.com/superuser404notfound/Sodalite
 
 Apple TV 4K and tvOS 26+ required.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <img src="https://img.shields.io/badge/status-public%20beta-orange">
 </p>
 
-> 🧪 **Public Beta is open.** Install via TestFlight: **https://testflight.apple.com/join/eFKDaaXr**
+> 🧪 **Public Beta is open.** Install via TestFlight: **https://testflight.apple.com/join/nWeQzmBX**
 > See [BETA.md](BETA.md) for what to focus on and how to report bugs.
 
 ---


### PR DESCRIPTION
## Summary

Replace the old JellySeeTV TestFlight code (`eFKDaaXr`) with the new Sodalite public beta code (`nWeQzmBX`) across:

- `README.md` — top badge
- `BETA.md` — install instructions
- `Marketing/Launch.md` — Reddit/Mastodon/Bluesky drafts (×6 occurrences)

The old link still resolves for now (existing JellySeeTV testers stay on it until they migrate via the farewell modal). After GitHub repo rename in Phase E, both links can coexist for the soft-sunset window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)