### PR TITLE
chore: security policy link → Sodalite repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/superuser404notfound/JellySeeTV/security/policy
+    url: https://github.com/superuser404notfound/Sodalite/security/policy
     about: Please report security issues via email — do not open a public issue. See SECURITY.md for details.
   - name: Jellyfin server bug
     url: https://github.com/jellyfin/jellyfin/issues


### PR DESCRIPTION
Last residual GitHub URL pointing at the old repo name. Auto-redirect handles it for now but a direct edit is cleaner long-term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)