### PR TITLE
fix(logo): show Sodalite gem in brand color (was solid white box)

### DIFF
--- a/Sodalite/App/SplashView.swift
+++ b/Sodalite/App/SplashView.swift
@@ -9,8 +9,9 @@ import SwiftUI
 /// minimum on-screen time is `appearDuration + holdDuration` so the
 /// splash never just blinks past on a fast session restore.
 ///
-/// Supporters see the gold "Premium" variant rendered in its original
-/// colors. Everyone else sees the standard white template logo.
+/// Supporters see the crowned "Premium" variant. Everyone else sees
+/// the standard Sodalite gem — both render in their full sodalite-blue
+/// brand colors, no template tint.
 struct SplashView: View {
 
     @Environment(\.dependencies) private var dependencies
@@ -41,15 +42,11 @@ struct SplashView: View {
     @ViewBuilder
     private var logo: some View {
         if dependencies.storeKitService.isSupporter {
-            // Premium logo ships with original rendering intent, so the
-            // gold color comes through without a `renderingMode` override.
             Image("PremiumLogo_Hero")
                 .resizable()
         } else {
             Image("Logo")
                 .resizable()
-                .renderingMode(.template)
-                .foregroundStyle(.white)
         }
     }
 

--- a/Sodalite/Features/Auth/ServerDiscoveryView.swift
+++ b/Sodalite/Features/Auth/ServerDiscoveryView.swift
@@ -12,8 +12,6 @@ struct ServerDiscoveryView: View {
                 VStack(spacing: 24) {
                     Image("Logo")
                         .resizable()
-                        .renderingMode(.template)
-                        .foregroundStyle(.white)
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 120, height: 120)
 

--- a/Sodalite/Features/Settings/SettingsView.swift
+++ b/Sodalite/Features/Settings/SettingsView.swift
@@ -236,8 +236,7 @@ struct SettingsView: View {
         } else {
             Image("Logo")
                 .resizable()
-                .renderingMode(.template)
-                .foregroundStyle(.white.opacity(0.5))
+                .opacity(0.85)
         }
     }
 


### PR DESCRIPTION
## Problem

In Sodalite, the Splash icon and the Settings footer logo render as a solid white rectangle — exactly what the user reported.

## Cause

`SplashView`, `ServerDiscoveryView` and `SettingsView` all wrap `Image("Logo")` with:

```swift
.renderingMode(.template)
.foregroundStyle(.white)
```

That worked when "Logo" was an alpha-glyph (the old JellySeeTV mark on transparent BG) — every opaque pixel became part of the mask, and white fill produced the J-shape silhouette.

The new Sodalite gem is shipped as a 512+1024 RGB PNG — no alpha. Every pixel is opaque, so the mask is the entire rectangle, and white fill paints a white box.

## Fix

Drop `.renderingMode(.template)` + `.foregroundStyle(...)` in all three call sites. The Sodalite gem renders in its own brand color with the white calcite veining intact, which is what users expect after the rebrand. The Settings footer keeps its dimmed look via `.opacity(0.85)` directly on the colored image.

## Files

- `Sodalite/App/SplashView.swift`
- `Sodalite/Features/Auth/ServerDiscoveryView.swift`
- `Sodalite/Features/Settings/SettingsView.swift`

## Verification

- `xcodebuild -scheme Sodalite -destination 'generic/platform=tvOS' CODE_SIGNING_ALLOWED=NO build` → ✅ `** BUILD SUCCEEDED **`
- Run on tvOS simulator → confirm splash shows the blue gem (not a white box)
- Open Settings → scroll to footer → confirm logo is the Sodalite gem at ~85% opacity
- Add a server → ServerDiscovery shows the brand gem at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)