### PR TITLE
docs: fix DV signaling claim, dead CLI link, stale beta build string

### DIFF
--- a/BETA.md
+++ b/BETA.md
@@ -85,7 +85,7 @@ Please include:
 1. **What you did**: exact steps
 2. **What you expected**
 3. **What actually happened**
-4. **Build version**: Settings, scroll to the bottom, e.g. `0.1.0 (1)`
+4. **Build version**: Settings, scroll to the bottom, e.g. `0.12.0 (1)`
 5. **tvOS version**: Settings on the Apple TV, System, About
 6. **Jellyfin server version** if relevant
 7. **A photo of the screen** if it's a visual bug. Taking a screenshot from the Siri Remote (`TV` + `Play/Pause`) lands the file on your Mac via Photos.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The Seerr integration isn't a tacked-on link to a web view. It's a first-class p
 
 ### 🎬 Watch
 - **Direct Play** for almost every codec on your server: H.264, HEVC, HEVC Main10, AV1, VP9, VP8, MPEG-4 Part 2 (XVID / DIVX), MPEG-2, VC-1. Containers: MKV, MP4, MOV, AVI, MPEG-TS, M2TS, VOB, 3GP, WebM, OGG, FLV. Server-side transcoding stays reserved for fringe codecs (WMV3, Theora, RealVideo).
-- **HDR10, HDR10+, Dolby Vision, HLG**: auto-detected, sent through with full color metadata. HDR10+ streams forward per-frame ST 2094-40 dynamic metadata so HDR10+ TVs apply the source's tone-mapping curves; Dolby Vision streams signal as `dvh1` so DV-capable TVs switch into Dolby Vision mode for Profile 5, 8.1 and 8.4. The display switches to the matching HDR mode automatically (Match Content).
+- **HDR10, HDR10+, Dolby Vision, HLG**: auto-detected, sent through with full color metadata. HDR10+ streams forward per-frame ST 2094-40 dynamic metadata so HDR10+ TVs apply the source's tone-mapping curves; Dolby Vision streams switch DV-capable TVs into Dolby Vision mode for Profile 5, 8.1 and 8.4 (Profile 7 is converted to single-layer 8.1 on device so it engages DV too): Profile 5 signals via a bare `dvh1` track tag, while 8.1 and 8.4 carry `dvh1` in `SUPPLEMENTAL-CODECS` on an `hvc1` base. The display switches to the matching HDR mode automatically (Match Content).
 - **Dolby Atmos** via EAC3+JOC, wrapped as Dolby MAT 2.0 so your AVR's Atmos light actually comes on
 - **Multichannel surround**: 5.1, 7.1 with correct channel layout
 - **Resume** from where you left off, on any device
@@ -189,7 +189,7 @@ If you also want to work on the engine, clone it next to this repo and switch th
 
 Xcode 26+ and Swift 6.0+ are required.
 
-For engine-level debugging without an Apple TV in the loop, AetherEngine ships a standalone macOS CLI (`aetherctl probe / serve / validate <url>`). See the [AetherEngine README](https://github.com/superuser404notfound/AetherEngine#aetherctl) for usage.
+For engine-level debugging without an Apple TV in the loop, AetherEngine ships a standalone macOS CLI (`aetherctl probe / serve / validate <url>`). See [AetherEngine's CLI docs](https://github.com/superuser404notfound/AetherEngine/blob/main/docs/cli.md) for usage.
 
 ## Roadmap
 


### PR DESCRIPTION
Audited Sodalite's public docs (README, BETA, SECURITY, and the local-only CLAUDE.md) against the actual code at 0.12.0 (AetherEngine 4.6.3). Most was accurate; this fixes the real drift.

## README.md
- **Dolby Vision claim corrected.** The Watch bullet said Dolby Vision "signals as `dvh1`" for Profile 5, 8.1 and 8.4. Only Profile 5 emits a bare `dvh1` track tag; 8.1 and 8.4 carry `dvh1` in `SUPPLEMENTAL-CODECS` on an `hvc1` base, and Profile 7 is converted to single-layer 8.1 on device. Reworded to match the engine (the AetherEngine docs were just corrected on the same point).
- **Dead link fixed.** The "Building from source" section linked `AetherEngine#aetherctl`, but that anchor no longer exists (the CLI section moved to `docs/cli.md`). Now points to `blob/main/docs/cli.md`.

## BETA.md
- Build-version example was `0.1.0 (1)`; bumped to `0.12.0 (1)` so testers don't read it as the current version range.

## Verified accurate (no change needed)
- README codec/container lists match `DirectPlayProfile.swift` exactly; all feature bullets map to shipping code; 26 locales confirmed in `Localizable.xcstrings`; tvOS 26.0 deployment target matches; all screenshot/asset paths resolve.
- SECURITY.md: correct repo, contact, and scope. (One optional nicety noted below.)

## Not in this PR
- **CLAUDE.md** is `.gitignore`d local-only state ("never publish"), so its parallel corrections are applied on disk but stay out of git: the "no test target" line (a `SodaliteTests` Swift Testing target exists), `handleDeepLink` ownership (`SodaliteApp`, not `AppRouter`), preference-store locations (scattered across feature dirs, not all under `Features/Settings/`), and three undocumented subsystems (`Services/Deletion/`, `Features/Settings/ParentalControls/`, `MusicPlaybackCoordinator`).
- **SECURITY.md** has no supported-versions table. Left as-is: which versions receive fixes is a policy call for the maintainer, not a doc bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)