### PR TITLE
Stats overlay reports the software path's read-ahead

### DIFF
--- a/Sodalite/Localizable.xcstrings
+++ b/Sodalite/Localizable.xcstrings
@@ -7,6 +7,489 @@
     " " : {
 
     },
+    "player.stats.decodeCushion" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rezerva dekodéru"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dekoderreserve"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Decoder-Reserve"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Απόθεμα αποκωδικοποιητή"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Decode cushion"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reserva del decodificador"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dekooderin varanto"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réserve du décodeur"
+          }
+        },
+        "hr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pričuva dekodera"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dekóder tartalék"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riserva del decoder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デコード余裕"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "디코드 여유"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dekoderreserve"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Decoderreserve"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zapas dekodera"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reserva do decodificador"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reserva do descodificador"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rezervă decodor"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запас декодера"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rezerva dekodéra"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avkodarreserv"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kod çözme payı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запас декодера"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解码余量"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "解碼餘量"
+          }
+        }
+      }
+    },
+    "player.stats.frameDelay" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zpoždění snímků"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Billedforsinkelse"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frame-Verzögerung"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Καθυστέρηση καρέ"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frame delay"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retraso de fotogramas"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ruutujen viive"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retard des images"
+          }
+        },
+        "hr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kašnjenje sličica"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Képkocka-késés"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ritardo dei fotogrammi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フレーム遅延"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "프레임 지연"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bildeforsinkelse"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Framevertraging"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opóźnienie klatek"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atraso de quadros"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atraso de fotogramas"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Întârziere cadre"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Задержка кадров"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oneskorenie snímok"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bildfördröjning"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kare gecikmesi"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Затримка кадрів"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "帧延迟"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "影格延遲"
+          }
+        }
+      }
+    },
+    "player.stats.readerAhead" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Náskok čtečky"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Læserforspring"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reader-Vorlauf"
+          }
+        },
+        "el" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Προφόρτωση αναγνώστη"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reader ahead"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adelanto del lector"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lukijan ennakko"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avance du lecteur"
+          }
+        },
+        "hr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prednost čitača"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Olvasó előtöltés"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anticipo del reader"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リーダー先読み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "리더 선행"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leserforsprang"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reader-voorsprong"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zapas czytnika"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adiantamento do leitor"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adiantamento do leitor"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avans cititor"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Опережение чтения"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Náskok čítačky"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Läsarförsprång"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İleri okuma"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Випередження читання"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "读取预取"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "讀取預取"
+          }
+        }
+      }
+    },
     "—" : {
       "comment" : "A placeholder text that is displayed when a value is unavailable.",
       "isCommentAutoGenerated" : true

--- a/Sodalite/Player/UI/StatsOverlayView.swift
+++ b/Sodalite/Player/UI/StatsOverlayView.swift
@@ -174,13 +174,26 @@ struct StatsOverlayView: View {
                     average: telemetry?.averageBitrateMbps
                 )
             )
-            row(
-                "player.stats.buffer",
-                value: Self.formatBufferPair(
-                    seconds: telemetry?.forwardBufferSeconds,
-                    cachedBytes: telemetry?.cachedBytes
+            // Both halves are native-only, so on the software path the row would read "— · — cached".
+            // The two rows below carry what that path holds instead (AetherEngine#306).
+            if telemetry?.forwardBufferSeconds != nil || telemetry?.cachedBytes != nil {
+                row(
+                    "player.stats.buffer",
+                    value: Self.formatBufferPair(
+                        seconds: telemetry?.forwardBufferSeconds,
+                        cachedBytes: telemetry?.cachedBytes
+                    )
                 )
-            )
+            }
+            // Decoded video queued past the clock. Sub-second on a healthy software session: the
+            // demux loop reads on renderer back-pressure, so this is a cushion, not a buffer.
+            if let cushion = telemetry?.displayCushionSeconds {
+                row("player.stats.decodeCushion", value: String(format: "%.2f s", cushion))
+            }
+            // Fetched but not yet demuxed: the runway that does exist ahead of the read cursor.
+            if let ahead = telemetry?.readerWindowAheadBytes {
+                row("player.stats.readerAhead", value: Self.formatByteCount(Int64(ahead)))
+            }
             row(
                 "player.stats.network",
                 value: Self.formatNetworkPair(
@@ -190,6 +203,9 @@ struct StatsOverlayView: View {
             )
             if let dropped = telemetry?.droppedFrameCount {
                 row("player.stats.droppedFrames", value: "\(dropped)")
+            }
+            if let delay = telemetry?.accumulatedFrameDelaySeconds {
+                row("player.stats.frameDelay", value: String(format: "%.2f s", delay))
             }
             if let fps = telemetry?.observedFps {
                 row("player.stats.fpsObserved", value: String(format: "%.2f fps", fps))


### PR DESCRIPTION
Consumer side of AetherEngine#306, which shipped in [6.9.0](https://github.com/superuser404notfound/AetherEngine/releases/tag/6.9.0) (already pinned on main, 6db4b5fb).

## Before

The Live section read fields that only the native path fills. On a software session (VP9, AV1 without hardware decode, MPEG-4 Part 2) the buffer row printed `— · — cached`, and the bitrate and network rows printed `0.0 Mbps` against a stream playing perfectly, because the engine's byte counter resolved through a session that path does not own.

## Now

| row | shown when | source |
|---|---|---|
| Buffer | native | unchanged, but hidden rather than printing two dashes when both halves are nil |
| Decode cushion | software | `displayCushionSeconds` |
| Reader ahead | both | `readerWindowAheadBytes` |
| Frame delay | software | `accumulatedFrameDelaySeconds` |
| Dropped frames | now both | `droppedFrameCount`, populated on software since 6.9.0 |

The cushion is deliberately its own row rather than folded into Buffer. It is sub-second by construction (0.2 to 0.5 s on a healthy session, because the software demux loop reads on renderer back-pressure), so printing it under a label a viewer reads as the network buffer would look like a permanent near-stall.

## Localisation

Three new keys across all 26 locales, real translations, no stubs: `player.stats.decodeCushion`, `player.stats.readerAhead`, `player.stats.frameDelay`. Catalog edited as lines, `git diff --numstat` is 483/0 (3 x 161 content lines, no cosmetic churn), and it stayed at 483/0 across an Xcode build.

## Verification

`Sodalite-tvOS` builds clean. The data side is already verified end to end against a real VP9 session in the engine release; this change is the presentation of it. Not yet checked on hardware, which needs a software-path title on the server.