### PR TITLE
The panel decision belongs to the engine, not to a combined tvOS flag (AE#459)

### DIFF
--- a/Sodalite/Player/PlayerViewModel+Live.swift
+++ b/Sodalite/Player/PlayerViewModel+Live.swift
@@ -261,7 +261,7 @@ extension PlayerViewModel {
             options: LoadOptions(
                 suppressDisplayCriteria: false,
                 forceDolbyVisionOnNonDVDisplay: preferences.forceDolbyVisionOnNonDVDisplay,
-                matchContentEnabled: Self.matchDynamicRangeEnabled,
+                matchContentEnabled: Self.matchContentEnabled,
                 panelIsInHDRMode: Self.panelIsInHDRMode,
                 audioBridgeMode: preferences.audioBridgeMode,
                 isLive: true,
@@ -384,7 +384,7 @@ extension PlayerViewModel {
         let options = LoadOptions(
             suppressDisplayCriteria: false,
             forceDolbyVisionOnNonDVDisplay: preferences.forceDolbyVisionOnNonDVDisplay,
-            matchContentEnabled: Self.matchDynamicRangeEnabled,
+            matchContentEnabled: Self.matchContentEnabled,
             panelIsInHDRMode: Self.panelIsInHDRMode,
             audioBridgeMode: preferences.audioBridgeMode,
             isLive: true,

--- a/Sodalite/Player/PlayerViewModel.swift
+++ b/Sodalite/Player/PlayerViewModel.swift
@@ -1052,7 +1052,7 @@ final class PlayerViewModel {
                 options: LoadOptions(
                     suppressDisplayCriteria: false,
                     forceDolbyVisionOnNonDVDisplay: preferences.forceDolbyVisionOnNonDVDisplay,
-                    matchContentEnabled: Self.matchDynamicRangeEnabled,
+                    matchContentEnabled: Self.matchContentEnabled,
                     panelIsInHDRMode: Self.panelIsInHDRMode,
                     audioBridgeMode: preferences.audioBridgeMode,
                     // Raw ASS event lines for the styled path; only affects ASS/SSA cue content.
@@ -1142,9 +1142,10 @@ final class PlayerViewModel {
         }
     }
 
-    /// Apple TV's "Match Dynamic Range" toggle; read when rendering the HDR badge so it only shows
-    /// when the panel actually engages HDR.
-    static var matchDynamicRangeEnabled: Bool {
+    /// tvOS's single "Match Content" flag. It covers Match Dynamic Range AND Match Frame Rate with no
+    /// way to tell them apart, which is exactly why it cannot answer whether the panel presents HDR
+    /// (AE#459); it is passed to the engine as the criteria-matching input and nothing else.
+    static var matchContentEnabled: Bool {
         #if os(tvOS)
         guard let win = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
@@ -1588,13 +1589,11 @@ final class PlayerViewModel {
                     print(line)
                     LogTap.shared.note(line)
                 }
-                // Only badge HDR if the panel went to HDR mode; with Match Dynamic Range off the TV stays SDR.
-                #if os(tvOS)
-                if format != .sdr, !Self.matchDynamicRangeEnabled {
-                    self.videoFormat = .sdr
-                    return
-                }
-                #endif
+                // AE#459: no second clamp here. The engine already publishes what the PANEL presents
+                // (`presentedVideoFormat`), and this one asked the wrong question: tvOS reports Match
+                // Dynamic Range and Match Frame Rate through one combined flag, so an Apple TV whose output
+                // format is fixed to HDR with matching off was relabelled SDR while it was demonstrably
+                // showing HDR, and it would have overridden the engine's late panel probe right back.
                 self.videoFormat = format
             }
             .store(in: &cancellables)


### PR DESCRIPTION
Companion to AetherEngine#463 (AetherEngine issue #459).

The `videoFormat` sink clamped an HDR label back to SDR whenever `isDisplayCriteriaMatchingEnabled` read false:

```swift
// Only badge HDR if the panel went to HDR mode; with Match Dynamic Range off the TV stays SDR.
if format != .sdr, !Self.matchDynamicRangeEnabled { self.videoFormat = .sdr; return }
```

That flag covers Match Dynamic Range **and** Match Frame Rate with no way to tell them apart, so it cannot answer whether the panel presents HDR. An Apple TV whose output format is fixed to HDR with matching off was relabelled SDR while it was demonstrably showing HDR, which is the host-side half of the same false negative AE#459 reports.

It was also redundant: with matching off, the engine writes no criteria, its attribution falls to host-driven, and it publishes SDR by itself. Left in place it would have overridden the engine's new late panel probe right back to SDR.

The property keeps its one honest job, feeding the engine's `matchContentEnabled` input, and is renamed to say what it actually reads.

Sodalite-tvOS tests: 1388 tests, 181 suites, 0 failures. tvOS build green.

Needs the engine fix to be visible end to end; on its own it only fixes the "Match Content entirely off, box fixed to HDR/DV" case.